### PR TITLE
Add progressr as dependence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     parallel,
     pliman (>= 3.0.0),
     plotly,
+    progressr,
     purrr,
     reactable,
     scales,


### PR DESCRIPTION
This PR explicitly adds progressr to the dependencies list to prevent potential crashes in UI functionalities when the package is missing.   

fix #5 